### PR TITLE
Fixed call() argument error and converted http library to requests

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,6 @@
 =====================
 Metasploit MSGRPC Modules
 Ryan Linn  <rlinn@trustwave.com>
-Marcello Salvati <byt3bl33d3r@gmail.com>
 http://www.trustwave.com
 =====================
 -----------------------------------------------------


### PR DESCRIPTION
This PR fixes a bug in the call() function where the opts argument wasn't cleared before returning the results.
Additionally the http library has been converted to requests.
